### PR TITLE
Add more keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   },
   "keywords": [
     "Gatsby",
+    "gatsby",
+    "gatsby-plugin",
     "plugin"
   ],
   "author": "",


### PR DESCRIPTION
## Changes
* Added `gatsby`, `gatsby-plugin` keywords to package.json
## Description
Hello. I found that the `package.json` file does not contain the keywords. In particular I added the keyword `gatsby-plugin`. This change will [submit the plugin to the Gatsby Plugin Library](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/). You can also go to gatsbyjs/gatsby#14013 for more detailed information. Thanks.